### PR TITLE
incorrect handling of uis names

### DIFF
--- a/gets-isat-source.R
+++ b/gets-isat-source.R
@@ -234,7 +234,7 @@ isat <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
     if(any(uis.names == "")){
       missing.colnames <- which(uis.names == "")
       for(i in 1:length(missing.colnames)){
-       uis.names[i] <- paste0("uisxreg", missing.colnames[i])
+       uis.names[missing.colnames[i]] <- paste0("uisxreg", missing.colnames[i])
       }
     }
 


### PR DESCRIPTION
the original code aims to replace the names of uis that are empty (== "") with names "uisxreg#". The current code replaces the wrong names and might leave some uis columns unnamed. The new code fixes this.