### PR TITLE
Changes to the tarball code

### DIFF
--- a/gets-make-and-check-tarball.R
+++ b/gets-make-and-check-tarball.R
@@ -34,6 +34,7 @@
 
 ##set working directory:
 setwd("C:/Users/sucarrat/Documents/R/gs/gets/devel/")
+# setwd("~/GitHub/gets/")
 #setwd(choose.dir()) #interactively
 
 ##where is the 'gets' package located?:
@@ -41,6 +42,7 @@ setwd("C:/Users/sucarrat/Documents/R/gs/gets/devel/")
 
 whereFolder <- "C:/Users/sucarrat/Documents/R/gs/gets/devel/gets"
 
+# whereFolder <- "~/GitHub/gets/gets"
 
 ####################################################
 ## 2 CLEAN WORK-DIRECTORY AND WORKSPACE
@@ -89,6 +91,40 @@ if( doDelete ){
   
 } #end if(doDelete)
 
+####################################################
+## 2.5 MOVE CODE TO TEMPORARY FOLDER - M-orca Feb 2021
+####################################################
+# Find the folder above our source code (i.e. the folder above the package structure)
+folder_above <- dirname(whereFolder)
+
+# Create a temporary folder there
+if(dir.exists(paste0(folder_above,"/temp"))){
+  unlink(dir.exists(paste0(folder_above,"/temp")))
+} else{
+  dir.create(paste0(folder_above,"/temp"))
+}
+
+# Copy the package to the temporary folder
+file.copy(from = whereFolder, to = paste0(folder_above,"/temp"), recursive = TRUE,overwrite = TRUE)
+
+### Remove Unwanted Files ###
+unlink(paste0(folder_above,"/temp/gets/tests"),recursive = TRUE)
+file.remove(c(paste0(folder_above,"/temp/gets/",c(".gitignore",".Rbuildignore","gets.Rproj"))))
+  
+
+# Remove Unwanted Text from the DESCRIPTION
+fileName <- paste0(folder_above,"/temp/gets/DESCRIPTION")
+text <- readChar(fileName, file.info(fileName)$size)
+# Remove testthat package from DESCRIPTION
+text <- gsub("lgarch, xtable, Matrix, microbenchmark, testthat","lgarch, xtable, Matrix, microbenchmark", text)
+# Remove Edition and line breaks from the DESCRIPTIONS
+text <- gsub("\nConfig/testthat/edition: 3\r\n|\r","", text)
+
+# Write the changes to the DESCRIPTION
+fileConn<-file(fileName)
+writeLines(text, fileConn)
+close(fileConn)
+
 
 ####################################################
 ## 3 BUILD AND CHECK THE TARBALL
@@ -107,13 +143,22 @@ if( doDelete ){
 ##i.e. the folder 'gets' with the source, is contained
 ##in whereFolder.
 
-system( paste0("R CMD build ", whereFolder, " --resave-data") )
+## M-orca, Feb 2021:
+system( paste0("R CMD build ", paste0(folder_above,"/temp/gets"), " --resave-data") )
+
+#system( paste0("R CMD build ", whereFolder, " --resave-data") )
 #system( paste0("R CMD build ", whereFolder, " --compact-vignettes") )
 
 ## - The --resave-data option is recommended by CRAN for
 ##   better compression, but it is not obligatory.
 ## - In principle, the latest development version of R should be
 ##   used for the build, but this sometimes leads to spurious errors.
+
+## M-orca, Feb 2021:
+### Remove temporary directory ### 
+unlink(paste0(folder_above,"/temp"),recursive = TRUE, force = TRUE)
+
+
 
 ##compress the vignette:
 ##======================


### PR DESCRIPTION
As discussed with G-Man @gsucarrat, I have uploaded code where the tarball code file now deletes any trace of the `testthat` package when creating the tarball. 

I have added the code as section 2.5 in the code. The code: 

1. Checks for a temporary directory in the folder *above* the package source code (which is in the `gets` folder) - therefore the temporary directory would be created at the level of this GitHub repository. If one exists, then it is deleted.
2. Then it (re-)creates a `temp` folder. 
3. It copies the entire package source to that folder.
4. Then it removes the `tests` folder as well as the `.Rproj`, `.gitignore` and `.RBuildignore` file. 
5. Then it opens the DESCRIPTION and removes the `testthat` package from the DESCRIPTION (including the local version reference).  It then saves a new DESCRIPTION file. 

Further below: 
It then creates a tarball **now from the `temp` folder rather than the original `gets` folder**.  Then we delete the `temp` folder. 

**Note**:  @gsucarrat it would be great if you could **check the directory logic** in there - I'm not entirely sure that the logic that I have used is the same as your file organisation i.e. whether what I think the working directory is, might not be the same level as for you. 

