### PR TITLE
mc warning is triggered with gets.isat

### DIFF
--- a/gets/R/gets-base-source.R
+++ b/gets/R/gets-base-source.R
@@ -4676,6 +4676,11 @@ getsm <- function(object, t.pval=0.05, wald.pval=t.pval, vcov.type=NULL,
         
     ##if( default estimator ):
     if( is.null(object$call$user.estimator) ){
+      
+      # Save original arx mc warning setting and disable it here
+      tmpmc <- getOption("mc.warning")
+      options(mc.warning = FALSE)
+      
       ##estimate specific model:
       est <- arx(yadj, mc=FALSE, mxreg=mXadj, vc=object$aux$vc,
         arch=object$aux$arch, asym=object$aux$asym,
@@ -4686,10 +4691,19 @@ getsm <- function(object, t.pval=0.05, wald.pval=t.pval, vcov.type=NULL,
         normality.JarqueB=normality.JarqueB,
         user.diagnostics=user.diagnostics, tol=object$aux$tol,
         LAPACK=object$aux$LAPACK, plot=FALSE)
+      
+      # Set the old arx mc warning again
+      options(mc.warning = tmpmc)
+      
     } #end if( default estimator )
 
     ##if( user-defined estimator ):
     if( !is.null(object$call$user.estimator) ){
+      
+      # Save original arx mc warning setting and disable it here
+      tmpmc <- getOption("mc.warning")
+      options(mc.warning = FALSE)
+      
       ##estimate specific:
       est <- arx(yadj, mc=FALSE, mxreg=mXadj,
         user.estimator=user.estimator,
@@ -4697,6 +4711,10 @@ getsm <- function(object, t.pval=0.05, wald.pval=t.pval, vcov.type=NULL,
         normality.JarqueB=normality.JarqueB,
         user.diagnostics=user.diagnostics, tol=object$aux$tol,
         LAPACK=object$aux$LAPACK, plot=FALSE)
+      
+      # Set the old arx mc warning again
+      options(mc.warning = tmpmc)
+      
     } #end if( user-defined estimator )
 
     ##delete, rename, add:
@@ -4924,6 +4942,11 @@ getsv <- function(object, t.pval=0.05, wald.pval=t.pval,
     normality.JarqueB <- TRUE
   }
 
+  
+  # Save original arx mc warning setting and disable it here
+  tmpmc <- getOption("mc.warning")
+  options(mc.warning = FALSE)
+  
   ## estimate model:
   est <- arx(e, mc=FALSE, vc=TRUE, vxreg=vXadj,
     zero.adj=object$aux$zero.adj, vc.adj=object$aux$vc.adj,
@@ -4931,6 +4954,9 @@ getsv <- function(object, t.pval=0.05, wald.pval=t.pval,
     normality.JarqueB=normality.JarqueB,
     user.diagnostics=user.diagnostics, tol=object$aux$tol,
     LAPACK=object$aux$LAPACK, plot=FALSE)
+  
+  # Set the old arx mc warning again
+  options(mc.warning = tmpmc)
 
   ## delete, rename and change various stuff:
   est$call <- est$date <- NULL

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -710,6 +710,10 @@ gets.isat <- function(x, t.pval=0.05, wald.pval=t.pval, vcov.type = NULL,
   mxreg <- x$aux$mX
   colnames(mxreg) <- x$aux$mXnames
 
+  # Save original arx mc warning setting and disable it here
+  tmpmc <- getOption("mc.warning")
+  options(mc.warning = FALSE)
+  
   object <- do.call("arx", 
                     list(y = y, mxreg = mxreg,
                          ewma = NULL, mc = FALSE, ar = NULL, log.ewma = NULL, # would be in mxreg already
@@ -725,6 +729,9 @@ gets.isat <- function(x, t.pval=0.05, wald.pval=t.pval, vcov.type = NULL,
                          singular.ok = TRUE,
                          plot = NULL))
 
+  # Set the old arx mc warning again
+  options(mc.warning = tmpmc)
+  
   ##github version:             
   #object <- as.arx(x, plot = FALSE, ar = FALSE) # some arguments pre-set because they will already be in isat if needed
   


### PR DESCRIPTION
The function `gets.isat` uses the `getsm` internally, which in turn uses `arx` internally. 
When using `gets.isat` before using `arx` in a session, the internal call to `arx` in `getsm` produces this warning: 

>Warning message:
>In arx(y = c(21, 21, 22.8, 21.4, 18.7, 18.1, 14.3, 24.4, 22.8, 19.2,  : 

>New default 'mc = TRUE' in arx() as of version 0.28
>This warning only appears the first time arx() is invoked
>To suppress this warning, set options(mc.warning = FALSE)

```r
# restart R session
library(gets)

obj <- lm(mpg ~ wt + hp + wt*disp + gear, mtcars)

is_obj <- isat(obj) 
gets(is_obj) # now throws warning because gets.isat uses getsm internally

gets(obj) # works because gets.lm does not use getsm but getsFun directly so never calls `arx`

```

This pull request fixes this