### PR TITLE
fixing the uis error

### DIFF
--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -658,12 +658,14 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
   
   ## Outlier Proportion and Distortion Test 
   # Proportion Test was previously executed in the print.isat function
-  if(!is.null(getsis$call$iis) & 
-     isTRUE(eval(getsis$call$iis) & 
-            !any(eval(getsis$call$sis), eval(getsis$call$tis), eval(getsis$call$uis))==TRUE)){
-    getsis$outlier.proportion.test <- outliertest(getsis)
-    getsis$outlier.distortion.test <- distorttest(getsis)
-  }
+  if(!is.null(getsis$call$iis) & isTRUE(eval(getsis$call$iis))){
+    if(!any(eval(getsis$call$sis), eval(getsis$call$tis), 
+            ifelse(is.logical(eval(getsis$call$uis)) & isTRUE(eval(getsis$call$uis)), TRUE, FALSE))){
+      
+      getsis$outlier.proportion.test <- outliertest(getsis)
+      getsis$outlier.distortion.test <- distorttest(getsis)
+      }
+    }
   
   return(getsis)
 


### PR DESCRIPTION
Simply changed an if statement. 

This is done in a really complicated fashion - I'm sure there are easier ways to do this!

I simply want to check: 
- Was IIS True? 
- if that is the case: were any of the other indicators used
- and also making sure that all of them are evaluated correctly (remember the situation where someone did `a <- TRUE; isat(y, iis = a)` and we had a problem with this)

I ran a few tests in the same file and they seemed to work.