### PR TITLE
Fix

### DIFF
--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -660,7 +660,8 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
   # Proportion Test was previously executed in the print.isat function
   if(!is.null(getsis$call$iis) & isTRUE(eval(getsis$call$iis))){
     if(!any(eval(getsis$call$sis), eval(getsis$call$tis), 
-            ifelse(is.logical(eval(getsis$call$uis)) & isTRUE(eval(getsis$call$uis)), TRUE, FALSE))){
+            ifelse(is.logical(eval(getsis$call$uis)) & isTRUE(eval(getsis$call$uis)), TRUE, FALSE),
+            identical(userEstArg$name, "ols"))){
       
       getsis$outlier.proportion.test <- outliertest(getsis)
       getsis$outlier.distortion.test <- distorttest(getsis)

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -661,7 +661,7 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
   if(!is.null(getsis$call$iis) & isTRUE(eval(getsis$call$iis))){
     if(!any(eval(getsis$call$sis), eval(getsis$call$tis), 
             ifelse(is.logical(eval(getsis$call$uis)) & isTRUE(eval(getsis$call$uis)), TRUE, FALSE),
-            identical(userEstArg$name, "ols"))){
+            !identical(userEstArg$name, "ols"))){
       
       getsis$outlier.proportion.test <- outliertest(getsis)
       getsis$outlier.distortion.test <- distorttest(getsis)


### PR DESCRIPTION
Do not run outlier or proportion test for user estimator (unless estimator name is "ols")