### PR TITLE
Fixing ar0

### DIFF
--- a/gets/R/gets-base-source.R
+++ b/gets/R/gets-base-source.R
@@ -2196,6 +2196,10 @@ arx <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
     )
   }
 
+  # Check ar argument
+  if(!(is.numeric(ar) | is.null(ar))){stop("The 'ar' argument must be NULL or numeric.")}
+  
+  
   ##regressand, regressors:
   #should be here instead of above/in the beginning?:
   #y.name <- deparse(substitute(y))

--- a/gets/R/gets-base-source.R
+++ b/gets/R/gets-base-source.R
@@ -2196,10 +2196,6 @@ arx <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
     )
   }
 
-  # Check ar argument
-  if(!(is.numeric(ar) | is.null(ar))){stop("The 'ar' argument must be NULL or numeric.")}
-  
-  
   ##regressand, regressors:
   #should be here instead of above/in the beginning?:
   #y.name <- deparse(substitute(y))

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -58,6 +58,9 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
     stop("No Indicator Selection Method was selected. Either set iis, sis or tis as TRUE or specify uis.")
   }
   
+  if(ar == 0){ar <- NULL}
+  if(!(is.numeric(ar) | is.null(ar))){stop("The 'ar' argument must be NULL or numeric.")}
+  
   ##name of regressand:
   y.name <- deparse(substitute(y))
   if( y.name[1] == "" ){ y.name <- "y" }

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -58,7 +58,7 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
     stop("No Indicator Selection Method was selected. Either set iis, sis or tis as TRUE or specify uis.")
   }
   
-  if(ar == 0){ar <- NULL}
+  if(!is.null(ar) && ar == 0){ar <- NULL}
   if(!(is.numeric(ar) | is.null(ar))){stop("The 'ar' argument must be NULL or numeric.")}
   
   ##name of regressand:


### PR DESCRIPTION

This fails:

```r
data(Nile)
isat(Nile, sis=TRUE, iis=FALSE, plot=TRUE, t.pval=0.005, ar = 0)
```

And the error message for these are also not great: 

```r
data(Nile)
isat(Nile, sis=TRUE, iis=FALSE, plot=TRUE, t.pval=0.005, ar = "1")

isat(Nile, sis=TRUE, iis=FALSE, plot=TRUE, t.pval=0.005, ar = "a")

isat(Nile, sis=TRUE, iis=FALSE, plot=TRUE, t.pval=0.005, ar = "0")

arx(Nile, plot=TRUE, ar = "a")
```

So I've added some fixes for this
