### PR TITLE
Removing `isat` dependence on `Sys.call()` when determining to do Outlier Distortion

### DIFF
--- a/0-test-files-by-G/gets-test-isat.R
+++ b/0-test-files-by-G/gets-test-isat.R
@@ -332,6 +332,9 @@ isat(y, sis=FALSE, uis=uis, max.paths=2)
 ##uis as data.frame:
 ##in an email 5/10-2020, F-bear reported an error produced by
 ##the following code:
+## UPDATE 08/2022: potentially fixed by M-orca
+# before, when passing a data.frame for uis, each column was split up into a separate list
+# now a data.frame is treated like a matrix
 set.seed(123)
 mx <- data.frame(matrix(runif(500),ncol=5))
 colnames(mx) <- paste("x", seq(1:5), sep="")

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -53,6 +53,41 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
   info.method <- match.arg(info.method)
   gof.method <- match.arg(gof.method)
   
+  isat.args <- list(
+    mc = mc, 
+    ar = ar, 
+    ewma = ewma,
+    iis = iis, 
+    sis = sis, 
+    tis = tis, 
+    uis = uis,
+    uis.logical = if(is.null(uis) | identical(uis, FALSE)){FALSE} else {TRUE}, 
+    blocks = blocks,
+    ratio.threshold = ratio.threshold, 
+    max.block.size = max.block.size, 
+    t.pval = t.pval,
+    wald.pval = wald.pval,
+    vcov.type = vcov.type,
+    do.pet = do.pet, 
+    ar.LjungB = ar.LjungB, 
+    arch.LjungB = arch.LjungB,
+    normality.JarqueB = normality.JarqueB,
+    info.method = info.method,
+    user.diagnostics = user.diagnostics, 
+    user.estimator = user.estimator,
+    gof.function = gof.function,
+    gof.method = gof.method,
+    include.gum = include.gum,
+    include.1cut = include.1cut, 
+    include.empty = include.empty, 
+    max.paths = max.paths,
+    parallel.options = parallel.options, 
+    turbo = turbo, 
+    tol = tol, 
+    LAPACK = LAPACK,
+    max.regs = max.regs
+  )
+  
   ##check that any indicator method is selected
   if(sis == FALSE && iis == FALSE && tis == FALSE && identical(uis, FALSE)){
     stop("No Indicator Selection Method was selected. Either set iis, sis or tis as TRUE or specify uis.")
@@ -133,19 +168,19 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
 
   } #end if(!is.null(parallel.options))
 
-#OLD:
-#  ##parallel.options argument:
-#  if(!is.null(parallel.options)){
-#    if(is.numeric(parallel.options)){
-#      clusterSpec <- parallel.options
-#    }
-#    OScores <- detectCores()
-#    if(parallel.options > OScores){
-#      stop("parallel.options > number of cores/threads")
-#    }
-#    #to do: enable exportCluster argument?
-#    #add: memory.limit()/memory.size() = max cores check?
-#  }
+  #OLD:
+  #  ##parallel.options argument:
+  #  if(!is.null(parallel.options)){
+  #    if(is.numeric(parallel.options)){
+  #      clusterSpec <- parallel.options
+  #    }
+  #    OScores <- detectCores()
+  #    if(parallel.options > OScores){
+  #      stop("parallel.options > number of cores/threads")
+  #    }
+  #    #to do: enable exportCluster argument?
+  #    #add: memory.limit()/memory.size() = max cores check?
+  #  }
 
   ##create regressors (no indicators), record info:
   mX <- regressorsMean(y, mc=mc, ar=ar, ewma=ewma, mxreg=mxreg,
@@ -225,9 +260,9 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
 
   ##user-defined indicators/variables:
   ##----------------------------------
-
-  #if uis is a matrix:
-  if(!is.list(uis) && !identical(as.numeric(uis),0)){
+  
+  #if uis is a matrix or a data.frame:
+  if(!is.list(uis) && !identical(as.numeric(uis),0) || is.data.frame(uis)){
 
     ##handle colnames:
     uis <- as.zoo(cbind(uis))
@@ -444,7 +479,7 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
         message("Searching...", appendLF=TRUE)
         #message("\n", appendLF=FALSE)
       }
-
+      
       blocksClust <- makeCluster(clusterSpec, outfile="") #make cluster
       clusterExport(blocksClust, clusterVarlist,
         envir=.GlobalEnv) #idea for the future?: envir=clusterEnvir
@@ -470,7 +505,7 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
         names(ISmatrices)[i], " variables... ",
         appendLF=TRUE)
     }
-
+    
     ##if no indicators retained from the blocks:
     if(length(ISspecific.models) == 0){
       isNames <- NULL
@@ -656,18 +691,23 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
   }
   if(plot){ plot.isat(getsis, coef.path=TRUE) }
   
-  ## Outlier Proportion and Distortion Test 
-  # Proportion Test was previously executed in the print.isat function
-  if(!is.null(getsis$call$iis) & isTRUE(eval(getsis$call$iis))){
-    if(!any(eval(getsis$call$sis), eval(getsis$call$tis), 
-##change suggested by J-bat (implemented by G-man 12 June 2022):
-            ifelse(is.logical(eval(getsis$call$uis)) & isTRUE(eval(getsis$call$uis)), TRUE, FALSE),
-            !identical(userEstArg$name, "ols"))){
-                  
-      getsis$outlier.proportion.test <- outliertest(getsis)
-      getsis$outlier.distortion.test <- distorttest(getsis)
-      }
-    }
+  
+  if(isat.args$iis & !any(isat.args$sis, isat.args$tis, isat.args$uis.logical)){
+    
+    ## Outlier Proportion and Distortion Test 
+    # Proportion Test was previously executed in the print.isat function
+    #if(!is.null(getsis$call$iis) & isTRUE(eval(getsis$call$iis))){
+    #  if(!any(eval(getsis$call$sis), eval(getsis$call$tis), 
+    ##change suggested by J-bat (implemented by G-man 12 June 2022):
+    #          ifelse(is.logical(eval(getsis$call$uis)) & isTRUE(eval(getsis$call$uis)), TRUE, FALSE),
+    #          !identical(userEstArg$name, "ols"))){
+                
+    getsis$outlier.proportion.test <- outliertest(getsis)
+    getsis$outlier.distortion.test <- distorttest(getsis)
+    #  }
+  }
+  
+  getsis$aux <- isat.args
   
   return(getsis)
 

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -436,10 +436,10 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
         ISspecific.models <- NULL
       }else{
         ISspecific.models <- names(getsis$specific.spec)
-#For the future?:
-#        ISgums[[j]] <- getsis$gum.mean
-#        ISpaths[[j]] <- getsis$paths
-#        ISterminals.results[[j]] <- getsis$terminals.results
+        #For the future?:
+        #        ISgums[[j]] <- getsis$gum.mean
+        #        ISpaths[[j]] <- getsis$paths
+        #        ISterminals.results[[j]] <- getsis$terminals.results
       }
 
       ##return
@@ -707,7 +707,7 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
     #  }
   }
   
-  getsis$aux <- isat.args
+  getsis$aux$args <- isat.args
   
   return(getsis)
 

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -692,7 +692,9 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
   if(plot){ plot.isat(getsis, coef.path=TRUE) }
   
   
-  if(isat.args$iis & !any(isat.args$sis, isat.args$tis, isat.args$uis.logical)){
+  if(isat.args$iis &&
+     identical(userEstArg$name, "ols") &&
+     !any(isat.args$sis, isat.args$tis, isat.args$uis.logical)){
     
     ## Outlier Proportion and Distortion Test 
     # Proportion Test was previously executed in the print.isat function


### PR DESCRIPTION
This aims to deal with the multiple issues introduced by relying on the `Sys.call()` argument. 

At the moment, this is only used explicitly in the part determining whether to carry out Outlier Distortion. 

## Motivating Error

Here is an example of the error: 

```r
data(Nile)
test_fun <- function(x = test1){
  isat(Nile, sis=TRUE, iis=TRUE, plot=TRUE, t.pval=0.005)
}
test_fun()
```
## Solution Approach

I now don't rely on the `Sys.call()` argument anymore. Rather I'm creating a new list object called `isat.args` that is subsequently saved in `getsis$aux$args`. 

This means that we can convert this: 

```r
## Outlier Proportion and Distortion Test 
  # Proportion Test was previously executed in the print.isat function
  if(!is.null(getsis$call$iis) & isTRUE(eval(getsis$call$iis))){
    if(!any(eval(getsis$call$sis), eval(getsis$call$tis), 
##change suggested by J-bat (implemented by G-man 12 June 2022):
            ifelse(is.logical(eval(getsis$call$uis)) & isTRUE(eval(getsis$call$uis)), TRUE, FALSE),
            !identical(userEstArg$name, "ols"))){
                  
      getsis$outlier.proportion.test <- outliertest(getsis)
      getsis$outlier.distortion.test <- distorttest(getsis)
      }
    }
```

To this: 

```r
if(isat.args$iis & !any(isat.args$sis, isat.args$tis, isat.args$uis.logical)){
    getsis$outlier.proportion.test <- outliertest(getsis)
    getsis$outlier.distortion.test <- distorttest(getsis)
  }
```

Essential is for me that @jkurle checks if this works with his package. I think you added this fix here: `!identical(userEstArg$name, "ols")` - do we need this again? Happy to add in that case.


I'm also fixing an error that was raised by F-bear in 2020. The error was like this: 

```r
##uis as data.frame:
##in an email 5/10-2020, F-bear reported an error produced by
##the following code:
set.seed(123)
mx <- data.frame(matrix(runif(500),ncol=5))
colnames(mx) <- paste("x", seq(1:5), sep="")
mx <- as.data.frame(mx)
#mx <- as.zoo(mx) #conversion to zoo solves the issue partially
yx <- 2*mx[,1] + rnorm(100, 0, 1)
is2 <- isat(yx, iis=TRUE, sis=FALSE, uis=mx, t.pval=0.01)
is2
```

This used to fail as a data.frame was not treated the same as a matrix - a data.frame used to be broken up by column and each column was turned into a list. Now a data.frame is treated like a matrix.

