### PR TITLE
Removing call dependence of `outliertest`, `distorttest`, `isatvarcorrect` as well

### DIFF
--- a/gets/R/gets-isat-outlier-distortion-source.R
+++ b/gets/R/gets-isat-outlier-distortion-source.R
@@ -5,9 +5,9 @@ distorttest <- function(x, coef="all"){
   if (is.null(x)){stop("Object is NULL - please make sure to pass an isat object.")}
   classx <- class(x)
   if (classx!="isat"){ stop("x must be an isat object")}
-  if (any(x$call$sis, x$call$tis, x$call$uis)==TRUE){stop("Test only valid for iis - not valid for sis, uis, or tis.")} 
+  if (any(x$aux$args$sis, x$aux$args$tis, x$aux$args$uis_logical)==TRUE){stop("Test only valid for iis - not valid for sis, uis, or tis.")} 
   if (all(coef != "all") && any(!coef %in% names(coef(x)))){stop("The 'coef' variable or vector contains one or more regressors not in the isat object.")}
-  if (x$call$iis != TRUE){stop("The isat object has not selected iis = TRUE. This is necessary for this test. Re-estimate isat with iis = TRUE.")}
+  if (x$aux$args$iis != TRUE){stop("The isat object has not selected iis = TRUE. This is necessary for this test. Re-estimate isat with iis = TRUE.")}
   # WRONG CHECK - Therefore commented out: if (is.null(x$ISnames)){stop("IIS did not identify any Indicators (Outliers). Therefore OLS = IIS and no distortion is detectable.")}
   
   ISnames <- c(x$ISnames[grep("iis", x$ISnames)])
@@ -40,12 +40,12 @@ distorttest <- function(x, coef="all"){
   y.null <-  x$aux$y[n.null]
   
   
-  if (!is.null(x$call$ar)){
-    ar.call <- eval(x$call$ar)
+  if (!is.null(x$aux$args$ar)){
+    ar.call <- x$aux$args$ar
   }
   
-  if (!is.null(x$call$ar)){
-    mx.null <- x$aux$mX[(n.null-max(eval(x$call$ar))),keep] # M-orca note: this won't work with panels!!
+  if (!is.null(x$aux$args$ar)){
+    mx.null <- x$aux$mX[(n.null-max(x$aux$args$ar)),keep] # M-orca note: this won't work with panels!!
   } else{
     mx.null <- x$aux$mX[n.null,keep]
   }

--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -691,6 +691,7 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
   }
   if(plot){ plot.isat(getsis, coef.path=TRUE) }
   
+  getsis$aux$args <- isat.args
   
   if(isat.args$iis &&
      identical(userEstArg$name, "ols") &&
@@ -709,7 +710,7 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
     #  }
   }
   
-  getsis$aux$args <- isat.args
+  
   
   return(getsis)
 
@@ -2761,7 +2762,7 @@ isatvarcorrect <- function(x,   mcor = 1){
   
   classx <- class(x)
   if (classx=="isat"){
-    if (!is.null(x$call$iis) & x$call$iis==TRUE) 
+    if (!is.null(x$aux$args$iis) & x$aux$args$iis==TRUE) 
     {
       x$vcov.mean <- x$vcov.mean * as.numeric(isvarcor(x$aux$t.pval, 1)[2]^2)
       rel_names <- x$aux$mXnames[!(x$aux$mXnames %in% x$ISnames)]
@@ -2846,7 +2847,7 @@ outliertest <- function(x=NULL, noutl=NULL, t.pval=NULL, T=NULL,  m=1, infty=FAL
         # if (any(x$call$sis, x$call$tis)==TRUE ){
         #   stop("Test only valid for iis")
         # } else {
-        if (  x$call$iis == TRUE){
+        if (  x$aux$args$iis == TRUE){
           ISnames <- c(x$ISnames[grep("iis", x$ISnames)])
           noutl= length(ISnames) 
           t.pval <- x$aux$t.pval


### PR DESCRIPTION
Same change as done to isat