### PR TITLE
fixing perfect linearity by fixing the mxkeep argument

### DIFF
--- a/gets/R/gets-isat-source.R
+++ b/gets/R/gets-isat-source.R
@@ -403,8 +403,10 @@ isat.default <- function(y, mc=TRUE, ar=NULL, ewma=NULL, mxreg=NULL,
       }
 
       ##apply dropvar:
+      mXis.names <- colnames(mXis)
       mXis <- dropvar(mXis, tol=tol, LAPACK=LAPACK,
         silent=!print.searchinfo)
+      mxkeep <- mxkeep[!mxkeep %in% which(!mXis.names %in% colnames(mXis))]
 
       ##print info:
       if(is.null(parallel.options)){


### PR DESCRIPTION
This is fixing issue #62. 

Currently the mxkeep argument is not adjusted when dropvar gets rid of a variable. Here again the example that fails with the current master branch: 

```r
library(gets)
data(hpdata)
y <- zooreg(hpdata$GCQ, 1959, frequency=4)
dlogy <- diff(log(y))
x <- zooreg(hpdata$GYDQ, 1959, frequency=4)
xmatrix <- as.zoo(ts(data.frame(GYDQ = diff(log(x))), start = index(dlogy)[1], end = index(dlogy)[144], frequency = 4))

a <- isat(dlogy, mxreg=xmatrix$GYDQ, iis=TRUE, sis = FALSE, t.pval =0.05, plot = TRUE)

xmatrix$GYDQ_lincom <- xmatrix$GYDQ * 4

b <- isat(dlogy, mxreg=xmatrix, iis=TRUE, sis = FALSE, t.pval =0.05, plot = TRUE)

a
b
```

I have now fixed this in the `ISblocksFun` function by adding the top and bottom line:

```r
mXis.names <- colnames(mXis)
mXis <- dropvar(mXis, tol=tol, LAPACK=LAPACK, silent=!print.searchinfo)
mxkeep <- mxkeep[!mxkeep %in% which(!mXis.names %in% colnames(mXis))]
```
